### PR TITLE
ethnam用のコンテナ作成

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 services:
-  php:
+  laravel:
     build: ./php-fpm
-    container_name: php
+    container_name: laravel
     volumes:
       - ../laravel:/var/www
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,15 @@ services:
     depends_on:
       - db
       - nginx
+  ethnam:
+    build: ./php-fpm
+    container_name: ethnam
+    volumes:
+      - ../ethnam:/var/www
+    restart: always
+    depends_on:
+      - db
+      - nginx
   nginx:
     image: nginx:alpine
     container_name: nginx

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -48,9 +48,9 @@ http {
             fastcgi_pass   $container:9000;
             fastcgi_index  index.php;
             include        fastcgi_params;
-            fastcgi_param  SCRIPT_FILENAME /var/www/public/index.php;
-            fastcgi_param  PATH_INFO /var/www/public/;
-            fastcgi_param  PATH_TRANSLATED /var/www/public/index.php;
+            fastcgi_param  SCRIPT_FILENAME /var/www/www/index.php;
+            fastcgi_param  PATH_INFO /var/www/www;
+            fastcgi_param  PATH_TRANSLATED /var/www/www/index.php;
         }
 
         location / {

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -43,6 +43,16 @@ http {
         ssl_ciphers         AESGCM:HIGH:!aNULL:!MD5;
         ssl_prefer_server_ciphers  on;
 
+        location  ~ ^/(ethnam) {
+            set $container "ethnam";
+            fastcgi_pass   $container:9000;
+            fastcgi_index  index.php;
+            include        fastcgi_params;
+            fastcgi_param  SCRIPT_FILENAME /var/www/public/index.php;
+            fastcgi_param  PATH_INFO /var/www/public/;
+            fastcgi_param  PATH_TRANSLATED /var/www/public/index.php;
+        }
+
         location / {
             set $container "php";
             fastcgi_pass   $container:9000;
@@ -52,5 +62,6 @@ http {
             fastcgi_param  PATH_INFO /var/www/public/;
             fastcgi_param  PATH_TRANSLATED /var/www/public/index.php;
         }
+
     }
 }

--- a/docker/php-fpm/php-fpm.conf
+++ b/docker/php-fpm/php-fpm.conf
@@ -6,8 +6,8 @@ daemonize = no
 access.log = /proc/self/fd/2
 catch_workers_output = yes
 clear_env = no
-user = nginx
-group = nginx
+user = apache
+group = apache
 listen = 127.0.0.1:9000
 listen = 9000
 


### PR DESCRIPTION
# 背景
- ethnam用の実習環境が必要
  - サクッと対応したいので、laravelのコンテナを流用する
# やったこと
- ethnam用のコンテナを作成
- https://localhost/ethnam へアクセスが有った際にethnamのコンテナへプロキシするようにした
